### PR TITLE
fix: do not allow pending accounts to call execute

### DIFF
--- a/packages/contracts/contracts/Account.sol
+++ b/packages/contracts/contracts/Account.sol
@@ -639,7 +639,7 @@ contract Account is ReentrancyGuard, IERC1271, IERC721Receiver, IERC1155Receiver
         Types.Signature memory sig = abi.decode(signature, (Types.Signature));
 
         CredentialInfo memory credentialInfo = credentials[sig.credentialId];
-        if (credentialInfo.role == Role.NONE) {
+        if (!_hasRole(sig.credentialId, Role.EXECUTOR)) {
             return false;
         }
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appliedblockchain/giano-contracts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "type": "commonjs",
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Revised credential verification to require a specific executor role for valid operation signatures, enhancing authorization security.
- **Tests**
  - Introduced new validations to ensure that pending credentials are prevented from executing transactions.
  - Improved test scenario formatting for clarity and maintainability.
- **Chores**
  - Updated the package version to reflect minor, backward-compatible improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->