### PR TITLE
add support to build tx, sign, and send in separete steps

### DIFF
--- a/packages/connector/src/provider.ts
+++ b/packages/connector/src/provider.ts
@@ -529,6 +529,54 @@ export const createGianoProvider = ({
       const parsedTypedData = typeof typedData === 'string' ? JSON.parse(typedData) : typedData
       return smartAccount.signTypedData(parsedTypedData)
     },
+    eth_signUserOperation: async ([userOp]: [any]) => {
+      console.log('eth_signUserOperation', { userOp })
+      if (!smartAccount) {
+        throw new Error('Giano not connected')
+      }
+      
+      return smartAccount.signUserOperation(userOp)
+    },
+    eth_sendSignedUserOperation: async ([signedUserOp]: [any]) => {
+      console.log('eth_sendSignedUserOperation', { signedUserOp })
+      if (!smartAccount) {
+        throw new Error('Giano not connected')
+      }
+      
+      const hash = await bundler.sendUserOperation(signedUserOp)
+      const { receipt: txReceipt } = await bundler.waitForUserOperationReceipt({ hash })
+      return txReceipt
+    },
+    eth_prepareUserOperation: async ([calls, options = {}]: [Call[], any]) => {
+      console.log('eth_prepareUserOperation', { calls, options })
+      if (!smartAccount) {
+        throw new Error('Giano not connected')
+      }
+      
+      const op = {
+        ...(paymaster && { paymaster }),
+        calls,
+        ...options,
+      }
+      
+      const estimate = await bundler.estimateUserOperationGas({ account: smartAccount, ...op })
+      if (!estimate) {
+        throw new Error('Could not estimate user operation')
+      }
+      
+      const prepared = await bundler.prepareUserOperation({
+        account: smartAccount,
+        ...op,
+        ...estimate,
+      })
+      
+      return {
+        ...prepared,
+        preVerificationGas: prepared.preVerificationGas,
+        maxFeePerGas: options.maxFeePerGas || parseGwei('200'),
+        maxPriorityFeePerGas: options.maxPriorityFeePerGas || parseGwei('400'),
+      }
+    },
   }
 
   methods.wallet_switchEthereumChain([{ chainId: initialChainId.toString(16) }])

--- a/services/custom-example/src/pages/index.tsx
+++ b/services/custom-example/src/pages/index.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head'
 import React, { type FormEvent } from 'react'
 import { useEffect, useState } from 'react'
 import { formatEther, parseEther } from 'viem'
+import { encodeFunctionData } from 'viem'
 import {
   useAccount,
   useConnect,
@@ -15,7 +16,7 @@ import {
 import styles from '../styles/Home.module.css'
 import { gianoConnector } from '../wagmi'
 
-const PRIVATE_ERC20_ADDRESS = '0xA6ED5f9baB12B749CD9Dc2ED73320eadb055D9B9'
+const PRIVATE_ERC20_ADDRESS = '0xfE96b00Fb176b14Ee1dd87ecFf1eEEADb8562571'
 
 const Home: NextPage = () => {
   const [mounted, setMounted] = useState(false)
@@ -42,9 +43,13 @@ const Home: NextPage = () => {
   })
 
   const [inputMessage, setInputMessage] = useState('')
+  const [manualMintAmount, setManualMintAmount] = useState('')
   const [contractState, setContractState] = useState<bigint | null>(null)
   const [signatureResult, setSignatureResult] = useState<string>('')
   const [messageToSign, setMessageToSign] = useState('Hello, please sign this message!')
+  const [isManualMintPending, setIsManualMintPending] = useState(false)
+  const [preparedUserOp, setPreparedUserOp] = useState<any>(null)
+  const [isUserOpSigned, setIsUserOpSigned] = useState(false)
 
   useEffect(() => {
     setMounted(true)
@@ -85,7 +90,7 @@ const Home: NextPage = () => {
       setConnectionReady(false)
     }
   }, [isConnected, address, status])
-
+  
   useEffect(() => {
     if (error) {
       console.error(error)
@@ -101,6 +106,136 @@ const Home: NextPage = () => {
       functionName: 'mint',
       args: [parseEther(inputMessage.trim())],
     })
+  }
+
+  // New method 1: Prepare user operation manually
+  const prepareManualMint = async () => {
+    if (!walletClient || !manualMintAmount.trim()) return
+    
+    try {
+      setIsManualMintPending(true)
+      
+      // Encode the mint function call
+      const mintCallData = encodeFunctionData({
+        abi: privateErc20Abi,
+        functionName: 'mint',
+        args: [parseEther(manualMintAmount.trim())],
+      })
+
+      // Prepare the user operation using the new method
+      const userOp = await walletClient.request({
+        method: 'eth_prepareUserOperation',
+        params: [[{
+          to: PRIVATE_ERC20_ADDRESS,
+          data: mintCallData,
+        }], {
+          // Optional: customize gas settings
+          maxFeePerGas: '0x2E90EDD000', // 200 gwei in hex
+          maxPriorityFeePerGas: '0x5D21DBA000', // 400 gwei in hex
+        }],
+      } as any)
+      
+      setPreparedUserOp(userOp)
+      console.log('User operation prepared:', userOp)
+      console.log('UserOp signature:', userOp?.signature)
+      setIsUserOpSigned(false) // Reset signed state when preparing new operation
+    } catch (error) {
+      console.error('Failed to prepare user operation:', error)
+    } finally {
+      setIsManualMintPending(false)
+    }
+  }
+
+  // New method 2: Sign prepared user operation
+  const signPreparedUserOp = async () => {
+    if (!walletClient || !preparedUserOp) return
+    
+    try {
+      setIsManualMintPending(true)
+      
+      const signature = await walletClient.request({
+        method: 'eth_signUserOperation',
+        params: [preparedUserOp],
+      } as any)
+      
+      // Add signature to the user operation
+      const signedUserOp = {
+        ...preparedUserOp,
+        signature,
+      }
+      
+      setPreparedUserOp(signedUserOp)
+      console.log('User operation signed:', signature)
+      setIsUserOpSigned(true) // Mark as signed
+    } catch (error) {
+      console.error('Failed to sign user operation:', error)
+    } finally {
+      setIsManualMintPending(false)
+    }
+  }
+
+  // New method 3: Send signed user operation
+  const sendSignedUserOp = async () => {
+    if (!walletClient || !preparedUserOp || !preparedUserOp.signature) return
+    
+    try {
+      setIsManualMintPending(true)
+      
+      const receipt = await walletClient.request({
+        method: 'eth_sendSignedUserOperation',
+        params: [preparedUserOp],
+      } as any)
+      
+      console.log('Transaction receipt:', receipt)
+      setPreparedUserOp(null) // Reset after successful send
+      setIsUserOpSigned(false) // Reset signed state
+      setManualMintAmount('') // Clear input
+    } catch (error) {
+      console.error('Failed to send signed user operation:', error)
+    } finally {
+      setIsManualMintPending(false)
+    }
+  }
+
+  // Full workflow in one function (alternative approach)
+  const manualMintFullWorkflow = async () => {
+    if (!walletClient || !manualMintAmount.trim()) return
+    
+    try {
+      setIsManualMintPending(true)
+      
+      // Step 1: Prepare
+      const mintCallData = encodeFunctionData({
+        abi: privateErc20Abi,
+        functionName: 'mint',
+        args: [parseEther(manualMintAmount.trim())],
+      })
+
+      const userOp = await walletClient.request({
+        method: 'eth_prepareUserOperation',
+        params: [[{ to: PRIVATE_ERC20_ADDRESS, data: mintCallData }]],
+      } as any)
+      
+      // Step 2: Sign
+      const signature = await walletClient.request({
+        method: 'eth_signUserOperation',
+        params: [userOp],
+      } as any)
+      
+      // Step 3: Send
+      const signedUserOp = { ...userOp, signature }
+      const receipt = await walletClient.request({
+        method: 'eth_sendSignedUserOperation',
+        params: [signedUserOp],
+      } as any)
+      
+      console.log('Manual mint completed:', receipt)
+      setManualMintAmount('')
+    } catch (error) {
+      console.error('Manual mint failed:', error)
+    } finally {
+      setIsManualMintPending(false)
+    }
   }
 
   const sendCall = async () => {
@@ -196,12 +331,72 @@ const Home: NextPage = () => {
           ? <button onClick={() => disconnect()}>Disconnect</button>
           : <button onClick={() => connect({ connector: gianoConnector })}>Connect</button>
         }
+        
+        {/* Original mint method */}
         <form className={styles.formContainer} onSubmit={sendTx}>
           <input className={styles.input} type="number" placeholder="Enter amount" value={inputMessage} onChange={(e) => setInputMessage(e.target.value)} />
-          <button className={styles.sendButton} disabled={isWritePending || !inputMessage.trim()}>
-            Mint
+          <button className={styles.sendButton} disabled={!isConnected || isWritePending || !inputMessage.trim()}>
+            Mint (Standard)
           </button>
         </form>
+
+        {/* New manual user operation methods */}
+        <div className={styles.formContainer}>
+          <h3>Manual Transaction Building</h3>
+          <input 
+            className={styles.input} 
+            type="number" 
+            placeholder="Amount to mint manually" 
+            value={manualMintAmount} 
+            onChange={(e) => setManualMintAmount(e.target.value)} 
+          />
+          
+          {/* Step-by-step approach */}
+          <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+            <button 
+              className={styles.readButton} 
+              disabled={!isConnected || isManualMintPending || !manualMintAmount.trim()} 
+              onClick={prepareManualMint}
+            >
+              1. Prepare UserOp
+            </button>
+            <button 
+              className={styles.readButton} 
+              disabled={!isConnected || isManualMintPending || !preparedUserOp || isUserOpSigned} 
+              onClick={signPreparedUserOp}
+            >
+              2. Sign UserOp
+            </button>
+            <button 
+              className={styles.readButton} 
+              disabled={!isConnected || isManualMintPending || !isUserOpSigned} 
+              onClick={sendSignedUserOp}
+            >
+              3. Send UserOp
+            </button>
+          </div>
+          
+          {/* Full workflow approach */}
+          <button 
+            className={styles.sendButton} 
+            disabled={!isConnected || isManualMintPending || !manualMintAmount.trim()} 
+            onClick={manualMintFullWorkflow}
+            style={{ marginTop: '10px' }}
+          >
+            Mint (Manual Full Workflow)
+          </button>
+          
+          {preparedUserOp && (
+            <div className={styles.stateCard}>
+              <p><strong>UserOp Status:</strong></p>
+              <p>Prepared: ✅</p>
+              <p>Signed: {isUserOpSigned ? '✅' : '❌'}</p>
+              <p>Signature: {preparedUserOp.signature || 'None'}</p>
+              <p>Nonce: {preparedUserOp.nonce}</p>
+            </div>
+          )}
+        </div>
+
         <button
           className={styles.readButton}
           disabled={


### PR DESCRIPTION
## Changes:
- Add support to `eth_signUserOperation`, `eth_sendSignedUserOperation` and `eth_prepareUserOperation` into the giano provider allowing the developer to have full control of the flow;
- Example of the 3 steps available on the FE.