### PR TITLE
remove keymapper and add to injector

### DIFF
--- a/packages/connector/src/provider.ts
+++ b/packages/connector/src/provider.ts
@@ -1,4 +1,3 @@
-import { credentialKeyMapperAbi } from '@appliedblockchain/giano-contracts'
 import type { Call, Hex, PublicClient } from 'viem'
 import {
   type Address,
@@ -6,7 +5,6 @@ import {
   concatHex,
   createPublicClient,
   type EIP1193Provider,
-  encodeFunctionData,
   type Hash,
   keccak256,
   parseGwei,
@@ -69,6 +67,8 @@ export interface GianoProviderInjection {
     chainType: ChainType
   }
   onCredentialSignedIn(credential: PublicKeyCredential): Promise<boolean> // method to control if the credential is signed in or not
+  getPublicKeyByCredentialId(idHash: Hash): Promise<{ x: Hex; y: Hex }>
+  onCredentialKey(idHash: Hash, xyVector: { x: Hex; y: Hex }): Promise<void>
 }
 
 export type CreateGianoProviderParams = {
@@ -78,7 +78,6 @@ export type CreateGianoProviderParams = {
   chains: readonly Chain[]
   transports: Record<number, Transport> | undefined
   injection: GianoProviderInjection
-  credentialKeyMapperAddress: Address
   gianoSmartWalletFactoryAddress: Address
 }
 
@@ -94,7 +93,6 @@ export const createGianoProvider = ({
   paymaster,
   bundler,
   injection,
-  credentialKeyMapperAddress,
   gianoSmartWalletFactoryAddress,
 }: CreateGianoProviderParams) => {
   let smartAccount: SmartAccount<GianoSmartAccountImplementation> | null
@@ -106,11 +104,6 @@ export const createGianoProvider = ({
   let staticSignatureLifetime = 0n
   const eventListeners: Partial<EventListeners> = {}
 
-  const credentialMapperContract = {
-    abi: credentialKeyMapperAbi,
-    address: credentialKeyMapperAddress,
-  };
-
   const emit = <E extends keyof EIP1193EventMap>(
     event: E,
     payload: Parameters<EIP1193EventMap[E]>[0],
@@ -119,13 +112,6 @@ export const createGianoProvider = ({
       listener => listener(payload)
     )
   }
-
-  const getPublicKeyByCredentialId = async (id: Hash) =>
-    client!.readContract({
-      ...credentialMapperContract,
-      functionName: 'getCredentialKey',
-      args: [id],
-    })
 
   const getWebAuthnAccount = async ({
     credentialId,
@@ -156,7 +142,7 @@ export const createGianoProvider = ({
       }
 
       const idHash = keccak256(new Uint8Array(rawCredential.rawId))
-      const { x, y } = await getPublicKeyByCredentialId(idHash)
+      const { x, y } = await injection.getPublicKeyByCredentialId(idHash)
 
       if (x === toHex(0, { size: 32 })) {
         throw new Error('Unknown credential ID')
@@ -383,16 +369,8 @@ export const createGianoProvider = ({
 
       const idHash = keccak256(toHex(new Uint8Array(credential.raw.rawId)))
       const xyVector = extractXYCoords(credential.publicKey)
-      const setCredentialKeyTx = {
-        to: credentialMapperContract.address,
-        data: encodeFunctionData({
-          abi: credentialMapperContract.abi,
-          functionName: 'setCredentialKey',
-          args: [idHash, xyVector],
-        }),
-      }
-
-      await methods.eth_sendTransaction([setCredentialKeyTx])
+      
+      injection.onCredentialKey(idHash, xyVector)
 
       // Store session data for new credential
       if (typeof window !== 'undefined') {

--- a/packages/connector/src/provider.ts
+++ b/packages/connector/src/provider.ts
@@ -113,6 +113,19 @@ export const createGianoProvider = ({
     )
   }
 
+  const ensureAccountDeployed = async (): Promise<boolean> => {
+    if (!smartAccount) return false
+    
+    try {
+      const accountAddress = await smartAccount.getAddress()
+      const accountCode = await client!.getCode({ address: accountAddress })
+      return !!(accountCode && accountCode !== '0x')
+    } catch (error) {
+      console.warn('Failed to check account deployment status:', error)
+      return false
+    }
+  }
+
   const getWebAuthnAccount = async ({
     credentialId,
     challenge,
@@ -211,6 +224,13 @@ export const createGianoProvider = ({
           console.warn('Smart account not available, falling back to regular call')
           return client!.request({ method: 'eth_call', params: [call, blockTag] })
         }
+      }
+
+      // Check if the account is deployed before attempting authenticated calls
+      const isDeployed = await ensureAccountDeployed()
+      if (!isDeployed) {
+        console.warn('Smart account not deployed yet, falling back to regular call')
+        return client!.request({ method: 'eth_call', params: [call, blockTag] })
       }
 
       // if the lifetime of the static signature is not known, fetch and cache it
@@ -369,8 +389,37 @@ export const createGianoProvider = ({
 
       const idHash = keccak256(toHex(new Uint8Array(credential.raw.rawId)))
       const xyVector = extractXYCoords(credential.publicKey)
-      
-      injection.onCredentialKey(idHash, xyVector)
+
+      // Check if the smart account is already deployed
+      const accountAddress = await smartAccount.getAddress()
+      const accountCode = await client!.getCode({ address: accountAddress })
+      const isDeployed = accountCode && accountCode !== '0x'
+
+      // NOTE: this is needed to deploy the smart account if we want to use it for read calls right away
+      // if not, the account will be deployed on the first actual transaction
+      if (!isDeployed) {
+        // Deploy the smart account with a minimal transaction
+        // Option 1: Send 0 ETH to self (minimal deployment transaction)
+        const deploymentTx = {
+          to: accountAddress,
+          value: '0x0',
+          data: '0x', // Empty data
+        }
+
+        try {
+          console.log('Deploying smart account...')
+          await methods.eth_sendTransaction([deploymentTx])
+          console.log('Smart account deployed successfully')
+        } catch (error) {
+          console.warn('Failed to deploy smart account:', error)
+          // If deployment fails, the account will be deployed on the first actual transaction
+        }
+      } else {
+        console.log('Smart account already deployed')
+      }
+
+      // Always call the injection callback regardless of deployment status
+      await injection.onCredentialKey(idHash, xyVector)
 
       // Store session data for new credential
       if (typeof window !== 'undefined') {

--- a/services/custom-example/src/giano-local-storage-injection.ts
+++ b/services/custom-example/src/giano-local-storage-injection.ts
@@ -93,5 +93,20 @@ export const gianoLocalStorageInjection: GianoProviderInjection = {
   onCredentialSignedIn: async (credential) => {
     console.log('Credential signed in', { credential })
     return true
-  }
+  },
+  getPublicKeyByCredentialId: async (idHash: Hash) => {
+    // get the public key from the local storage based on the onCredentialKey injection method
+    const publicKey = localStorage.getItem(`gpk-${idHash}-public-key`)
+    const publicKeyY = localStorage.getItem(`gpk-${idHash}-public-key-y`)
+    if (!publicKey || !publicKeyY) {
+      throw new Error('Public key not found')
+    }
+    return { x: publicKey, y: publicKeyY }
+  },
+  onCredentialKey: async (idHash: Hash, xyVector: { x: Hex; y: Hex }) => {
+    console.log('onCredentialKey', { idHash, xyVector })
+    // save the public key to the local storage
+    localStorage.setItem(`gpk-${idHash}-public-key`, xyVector.x)
+    localStorage.setItem(`gpk-${idHash}-public-key-y`, xyVector.y)
+  },
 }


### PR DESCRIPTION
### Changes:
- Remove the `CredentialKeyMapper` actions and replace with injector methods to get and set the credential/public key;
- Example in the FE with the injector added methods;
- Add dummy transaction to perform deploy of the smart account;