### PR TITLE
Portafino use raw credential

### DIFF
--- a/packages/connector/src/provider.ts
+++ b/packages/connector/src/provider.ts
@@ -5,8 +5,6 @@ import {
   concatHex,
   createPublicClient,
   type EIP1193Provider,
-  type Hash,
-  keccak256,
   parseGwei,
   toHex,
   type Transport,
@@ -68,8 +66,8 @@ export type GianoProviderInjection = {
     chainType: ChainType
   }
   onCredentialSignedIn(credential: PublicKeyCredential): Promise<boolean> // method to control if the credential is signed in or not
-  getPublicKeyByCredentialId(idHash: Hash): Promise<{ x: Hex; y: Hex }>
-  onCredentialKey(idHash: Hash, xyVector: { x: Hex; y: Hex }): Promise<void>
+  getPublicKeyByCredentialId(rawId: ArrayBuffer): Promise<{ x: Hex; y: Hex }>
+  onCredentialKey(rawId: ArrayBuffer, xyVector: { x: Hex; y: Hex }): Promise<void>
   onUserOperationSigned?: (signedUserOp: any) => Promise<any> // optional hook for backend validation and submission
 }
 
@@ -165,8 +163,7 @@ export const createGianoProvider = ({
         throw new Error('Failed to sign in with credential')
       }
 
-      const idHash = keccak256(new Uint8Array(rawCredential.rawId))
-      const { x, y } = await injection.getPublicKeyByCredentialId(idHash)
+      const { x, y } = await injection.getPublicKeyByCredentialId(rawCredential.rawId)
 
       if (x === toHex(0, { size: 32 })) {
         throw new Error('Unknown credential ID')
@@ -350,7 +347,6 @@ export const createGianoProvider = ({
       })
       const smartAccountAddress = await smartAccount.getAddress()
 
-      const idHash = keccak256(toHex(new Uint8Array(credential.raw.rawId)))
       const xyVector = extractXYCoords(credential.publicKey)
 
       // Check if the smart account is already deployed
@@ -382,7 +378,7 @@ export const createGianoProvider = ({
       }
 
       // Always call the injection callback regardless of deployment status
-      await injection.onCredentialKey(idHash, xyVector)
+      await injection.onCredentialKey(credential.raw.rawId, xyVector)
 
       // Store session data for new credential
       if (typeof window !== 'undefined') {

--- a/services/custom-example/src/giano-local-storage-injection.ts
+++ b/services/custom-example/src/giano-local-storage-injection.ts
@@ -1,5 +1,4 @@
 import type { GianoProviderInjection, ChainType } from '@appliedblockchain/giano-connector'
-import { Hash } from 'viem'
 
 function hexToBytes(hex: string) {
   hex = hex.replace(/^0x/g, '')
@@ -98,20 +97,20 @@ export const gianoLocalStorageInjection: GianoProviderInjection = {
     console.log('Credential signed in', { credential })
     return true
   },
-  getPublicKeyByCredentialId: async (idHash: Hash) => {
+  getPublicKeyByCredentialId: async (rawId: ArrayBuffer) => {
     // get the public key from the local storage based on the onCredentialKey injection method
-    const publicKey = localStorage.getItem(`gpk-${idHash}-public-key`)
-    const publicKeyY = localStorage.getItem(`gpk-${idHash}-public-key-y`)
+    const publicKey = localStorage.getItem(`gpk-${Buffer.from(rawId).toString('hex')}-public-key`)
+    const publicKeyY = localStorage.getItem(`gpk-${Buffer.from(rawId).toString('hex')}-public-key-y`)
     if (!publicKey || !publicKeyY) {
       throw new Error('Public key not found')
     }
     return { x: publicKey, y: publicKeyY }
   },
-  onCredentialKey: async (idHash: Hash, xyVector: { x: Hex; y: Hex }) => {
-    console.log('onCredentialKey', { idHash, xyVector })
+  onCredentialKey: async (rawId: ArrayBuffer, xyVector: { x: Hex; y: Hex }) => {
+    console.log('onCredentialKey', { rawId, xyVector })
     // save the public key to the local storage
-    localStorage.setItem(`gpk-${idHash}-public-key`, xyVector.x)
-    localStorage.setItem(`gpk-${idHash}-public-key-y`, xyVector.y)
+    localStorage.setItem(`gpk-${Buffer.from(rawId).toString('hex')}-public-key`, xyVector.x)
+    localStorage.setItem(`gpk-${Buffer.from(rawId).toString('hex')}-public-key-y`, xyVector.y)
   },
   onUserOperationSigned: async (signedUserOp) => {
     try {


### PR DESCRIPTION
### Changes:
- `getPublicKeyByCredentialId` and `onCredentialKey` now receive the `rawId(ArrayBuffer)` instead of the `hashId(Hash)`;
- FE example updated to receive and store the `rawId`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a modular, multi-owner ERC-4337 smart wallet system ("GianoSmartWallet") with upgradeability, advanced signature validation (EIP-712, ERC-1271, WebAuthn), and deterministic deployment via a factory.
  * Added a CredentialKeyMapper contract for mapping WebAuthn credential IDs to public keys.
  * Launched a full-featured example app integrating passkey authentication, manual and automatic user operation workflows, and contract interaction via a custom wallet connector.
  * Provided a permissive paymaster and private ERC-20 token contract for testing.

* **Improvements**
  * Enhanced documentation and setup instructions for both contracts and frontend.
  * Added comprehensive configuration files for Foundry, Hardhat, and wagmi.

* **Bug Fixes**
  * Improved error handling and validation across contracts and frontend workflows.

* **Tests**
  * Added extensive smart contract and integration tests for wallet, factory, multi-ownership, signature validation, and user operation scenarios.

* **Chores**
  * Updated and reorganized package scripts, dependencies, and environment configurations.
  * Refined .gitignore and added submodules for external dependencies.

* **Removals**
  * Removed legacy contracts, test helpers, and obsolete package files to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->