### PR TITLE
deploy cmd

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,10 +7,11 @@
     "build": "pnpm hh:compile && pnpm hh:wagmi && tsup index.ts",
     "hh:test": "NODE_ENV=test REPORT_GAS=true hardhat test",
     "hh:node": "anvil --enable-trace-printing",
-    "hh:deploy": "hardhat ignition deploy ignition/modules/index.ts --strategy create2",
+    "hh:deploy": "hardhat ignition deploy ignition/modules/GianoAccountFactory.ts --strategy create2",
+    "hh:deploy:mapper": "hardhat ignition deploy ignition/modules/index.ts --strategy create2",
+    "hh:deploy:testing": "hardhat ignition deploy ignition/modules/Testing.ts --strategy create2",
     "hh:localwipe": "rm -rf ignition/deployments/chain-31337",
     "hh:initlocal": "pnpm hh:localwipe && pnpm build && pnpm -w aa:deploy:local && pnpm hh:deploy --network localhost && pnpm hh:deploy:testing --network localhost",
-    "hh:deploy:testing": "hardhat ignition deploy ignition/modules/Testing.ts --strategy create2",
     "hh:compile": "hardhat compile",
     "hh:clean": "hardhat clean",
     "hh:wagmi": "wagmi generate"


### PR DESCRIPTION
TLDR: `hh:deploy` only deploy the wallet contracts.
example: `pnpm hh:deploy --network <network-name>`

![image](https://github.com/user-attachments/assets/9a7b1c28-9805-428c-a9ce-1fe3406a72e5)


This pull request updates the deployment scripts in the `packages/contracts/package.json` file to improve modularity and flexibility. The changes include introducing new deployment commands and reorganizing existing ones.

### Deployment Script Updates:
* Updated the `hh:deploy` script to deploy the `GianoAccountFactory.ts` module instead of the `index.ts` module.
* Added a new `hh:deploy:mapper` script for deploying the `index.ts` module.
* Reintroduced the `hh:deploy:testing` script for deploying the `Testing.ts` module, ensuring consistency with the deployment strategy.